### PR TITLE
ARM clock configuration

### DIFF
--- a/src/arm.rs
+++ b/src/arm.rs
@@ -151,7 +151,7 @@ impl Timings {
     }
 }
 
-pub const CCM_ANALOG_PLL_ARM: *mut u32 = 0x400D_8000 as _;
+const CCM_ANALOG_PLL_ARM: *mut u32 = 0x400D_8000 as _;
 
 const DIV_SEL: Field = Field::new(0, 0x7f);
 
@@ -265,7 +265,7 @@ pub unsafe fn set_frequency(hz: u32) -> (ARMClock, IPGClock) {
 ///
 /// The function assumes that the ARM clock runs on PLL1.
 /// The clock values may be incorrect until after the first call to
-/// [`set_frequency_arm`](crate::set_frequency_arm).
+/// [`set_frequency`].
 ///
 /// # Safety
 ///

--- a/src/arm.rs
+++ b/src/arm.rs
@@ -1,0 +1,296 @@
+//! ARM clock control
+//!
+//! The module provides routines to control the ARM clock frequency.
+//! Since the IPG clock runs on the AHB_CLK_ROOT signal, this module
+//! also controls IPG clock speeds.
+//!
+//! # Approach
+//!
+//! 1. Switch the AHB_CLK_ROOT to use the 24MHz clock provided by
+//!    peripheral clock 2. Use the glitchless muxes.
+//! 2. Compute the new ARM & IPG clock divider values, and the PLL1
+//!    loop divider value. Commit those values to registers.
+//! 3. Switch (back) to PLL1 as the AHB_CLK_ROOT.
+//!
+//! # References
+//!
+//! i.MX RT 1060 reference manual
+//! - Chapter 14: Clock Control Module (CCM)
+//!   - System Clocks
+//!   - CCM Internal Clock Generation
+
+use crate::register::Field;
+
+/// The ARM clock frequency
+///
+/// See [`Handle::set_frequency_arm`](crate::Handle::set_frequency_arm`)
+/// and [`Handle::frequency_arm`](crate::Handle::frequency_arm`) for safe
+/// mutators and accessors.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct ARMClock(pub u32);
+/// The IPG clock frequency
+///
+/// The IPG clock frequency runs on the AHB_CLOCK_ROOT. It's a divided
+/// ARM clock.
+///
+/// See [`Handle::set_frequency_arm`](crate::Handle::set_frequency_arm`)
+/// and [`Handle::frequency_arm`](crate::Handle::frequency_arm`) for safe
+/// mutators and accessors.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct IPGClock(pub u32);
+
+const CCM_CACCR: *mut u32 = 0x400F_C010 as _;
+const CCM_CBCDR: *mut u32 = 0x400F_C014 as _;
+
+/// Wait for all divider and mux handshakes to complete
+#[inline(always)]
+unsafe fn wait_for_handshake() {
+    const CCM_CDHIPR: *mut u32 = 0x400F_C048 as _;
+    while CCM_CDHIPR.read_volatile() != 0 {}
+}
+
+/// Runs the function when the AHB_CLK_ROOT is powered by the
+/// 24MHz crystal oscillator. When the function returns, AH_BCLK_ROOT
+/// is powered by the PRE_PERIPH_CLK source.
+///
+/// # Safety
+///
+/// Modifies CCM register memory.
+unsafe fn on_ahb_clk_oscillator<R>(func: impl FnOnce() -> R) -> R {
+    const CCM_CBCMR: *mut u32 = 0x400F_C018 as _;
+
+    const PERIPH_CLK2_PODF: Field = Field::new(27, 0b111);
+    const PERIPH_CLK2_SEL: Field = Field::new(12, 0b11);
+
+    PERIPH_CLK2_PODF.modify(CCM_CBCDR, 0); // Divide by 1
+    PERIPH_CLK2_SEL.modify(CCM_CBCMR, 1); // Derive from oscillator
+    wait_for_handshake();
+
+    // Switch main peripheral clock to PERIPH_CLK2
+    const PERIPH_CLK_SEL: Field = Field::new(25, 1);
+    PERIPH_CLK_SEL.modify(CCM_CBCDR, 1);
+    wait_for_handshake();
+
+    let result = func();
+
+    // Switch back to PRE_PERIPH_CLK
+    const PRE_PERIPH_CLK_SEL: Field = Field::new(18, 0x3);
+    PRE_PERIPH_CLK_SEL.modify(CCM_CBCMR, 3); // Select PLL1
+
+    PERIPH_CLK_SEL.modify(CCM_CBCDR, 0);
+    wait_for_handshake();
+
+    result
+}
+
+/// ARM clock timings
+#[derive(PartialEq, Eq, Debug)]
+struct Timings {
+    /// PLL_ARM DIV_SEL
+    ///
+    /// Valid range for divider value: 54-108. `Fout = Fin * div_select/2.0`
+    /// Fin is the 24MHz crystal oscillator
+    pll_arm_div_sel: u32,
+    /// Divider value for CACRR[ARM_PODF], in between the PLL
+    /// and the pre peripheral mux
+    ///
+    /// Note that this value is off-by-one to support runtime math.
+    /// Subtract 1 before writing to the field.
+    div_arm: u32,
+    /// Divider for CBCDR[AHB_PODF], right before the ARM
+    /// core clock input
+    ///
+    /// Note that this value is off-by-one to support runtime math.
+    /// Subtract 1 before writing to the field.
+    div_ahb: u32,
+    /// ARM clock frequency that we're using
+    arm_hz: u32,
+    /// IPG divider (off-by-one for runtime math; subtract 1 before writing)
+    div_ipg: u32,
+}
+
+#[inline(always)]
+fn compute_arm_hz(div_arm: u32, div_ahb: u32, pll_arm_div_sel: u32) -> u32 {
+    pll_arm_div_sel * 12_000_000 / div_arm / div_ahb
+}
+
+impl Timings {
+    /// Returns a `Timings` that approximates the target ARM clock `arm_hz`
+    fn target(arm_hz: u32) -> Self {
+        let (mut div_arm, mut div_ahb) = (1, 1);
+        while arm_hz * div_arm * div_ahb < 648_000_000 {
+            if div_arm < 8 {
+                div_arm += 1;
+            } else if div_ahb < 5 {
+                div_ahb += 1;
+                div_arm = 1;
+            } else {
+                break;
+            }
+        }
+
+        let pll_arm_div_sel = (arm_hz * div_arm * div_ahb + 6_000_000) / 12_000_000;
+        let pll_arm_div_sel = pll_arm_div_sel.min(108).max(54);
+        let arm_hz = compute_arm_hz(div_arm, div_ahb, pll_arm_div_sel);
+
+        let div_ipg = (arm_hz + 149_999_999) / 150_000_000;
+        let div_ipg = div_ipg.min(4);
+
+        Timings {
+            pll_arm_div_sel,
+            div_arm,
+            div_ahb,
+            arm_hz,
+            div_ipg,
+        }
+    }
+
+    /// Returns the IPG clock frequency described by these timings
+    fn ipg_hz(&self) -> u32 {
+        self.arm_hz / self.div_ipg
+    }
+}
+
+pub const CCM_ANALOG_PLL_ARM: *mut u32 = 0x400D_8000 as _;
+
+const DIV_SEL: Field = Field::new(0, 0x7f);
+
+/// Restart the ARM PLL with a new `div_sel` value
+///
+/// # Safety
+///
+/// Unsynchronized writes to CCM memory.
+unsafe fn restart_pll_arm(div_sel: u32) {
+    const POWERDOWN: Field = Field::new(12, 1);
+    const ENABLE: Field = Field::new(13, 1);
+
+    // Clear all bits except POWERDOWN
+    POWERDOWN.write_zero(CCM_ANALOG_PLL_ARM, 1);
+    // Clear POWERDOWN write above
+    DIV_SEL.write_zero(CCM_ANALOG_PLL_ARM, div_sel);
+    // Enable the PLL
+    ENABLE.modify(CCM_ANALOG_PLL_ARM, 1);
+
+    const LOCK: u32 = 1 << 31;
+    while CCM_ANALOG_PLL_ARM.read_volatile() & LOCK == 0 {}
+}
+
+const ARM_PODF: Field = Field::new(0, 0x7);
+const AHB_PODF: Field = Field::new(10, 0x7);
+const IPG_PODF: Field = Field::new(8, 0x3);
+
+/// Write the ARM timings throughout the CCM
+///
+/// # Safety
+///
+/// Unsynchronized writes to CCM memory.
+unsafe fn set_timings(timings: &Timings) {
+    ARM_PODF.modify(CCM_CACCR, timings.div_arm.saturating_sub(1));
+    wait_for_handshake();
+
+    AHB_PODF.modify(CCM_CBCDR, timings.div_ahb.saturating_sub(1));
+    wait_for_handshake();
+
+    IPG_PODF.modify(CCM_CBCDR, timings.div_ipg.saturating_sub(1));
+}
+
+/// Returns the ARM timings read from the CCM peripheral
+///
+/// Assumes that the ARM clock was configured using this module's API.
+/// If the ARM clock is not running on PLL1, these timings may be meaningless.
+///
+/// # Safety
+///
+/// Reads global, mutable memory.
+#[inline(always)]
+unsafe fn timings() -> Timings {
+    timings_(CCM_CACCR, CCM_CBCDR, CCM_ANALOG_PLL_ARM)
+}
+
+#[inline(always)]
+unsafe fn timings_(caccr: *const u32, cbcdr: *const u32, pll_arm: *const u32) -> Timings {
+    let div_arm = ARM_PODF.read(caccr) + 1;
+    let div_ahb = AHB_PODF.read(cbcdr) + 1;
+    let div_ipg = IPG_PODF.read(cbcdr) + 1;
+    let pll_arm_div_sel = DIV_SEL.read(pll_arm);
+    let arm_hz = compute_arm_hz(div_arm, div_ahb, pll_arm_div_sel);
+    Timings {
+        div_arm,
+        div_ahb,
+        pll_arm_div_sel,
+        arm_hz,
+        div_ipg,
+    }
+}
+
+/// Set the ARM clock frequency, returning the ARM and IPG clock speeds
+///
+/// The function will temporarily switch the ARM clock to the 24MHz clock
+/// while it modifies the clock speed. While in this switched state, the ARM
+/// core will execute instructions much more slowly than usual. To avoid
+/// negative performance, consider setting the ARM clock speed early in system
+/// startup, or by calling this function in a critical section.
+///
+/// The function lets you reconfigure the IPG clock frequency. Any peripherals
+/// that use the IPG clock may not be aware of this new clock frequency. You're
+/// responsible for updating any peripherals to reference the new clock speed.
+///
+/// When this function returns, the ARM clock runs on PLL1 (the "ARM PLL").
+///
+/// # Safety
+///
+/// Modifies CCM and CCM_ANALOG peripheral memory. This may be aliased
+/// elsewhere, and could be in the middle of a modification. Users should
+/// prefer the safer [`Handle::set_frequency_arm`](crate::Handle::set_frequency_arm)
+/// method.
+pub unsafe fn set_frequency(hz: u32) -> (ARMClock, IPGClock) {
+    on_ahb_clk_oscillator(|| {
+        let timings = Timings::target(hz);
+        restart_pll_arm(timings.pll_arm_div_sel);
+        set_timings(&timings);
+        (ARMClock(timings.arm_hz), IPGClock(timings.ipg_hz()))
+    })
+}
+
+/// Returns the ARM and IPG clock frequencies
+///
+/// The function assumes that the ARM clock runs on PLL1.
+/// The clock values may be incorrect until after the first call to
+/// [`set_frequency_arm`](crate::set_frequency_arm).
+///
+/// # Safety
+///
+/// Reads multiple CCM registers without synchronization. It's safer to use
+/// [`Handle::frequency_arm`](crate::Handle::frequency_arm) to read the frequencies.
+pub unsafe fn frequency() -> (ARMClock, IPGClock) {
+    let timings = timings();
+    (ARMClock(timings.arm_hz), IPGClock(timings.ipg_hz()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{timings_, Timings};
+
+    #[test]
+    fn imxrt1060_target_freq() {
+        let timings = Timings::target(600_000_000);
+        assert_eq!(timings.arm_hz, 600_000_000);
+        assert_eq!(timings.ipg_hz(), 150_000_000);
+        assert!(54 <= timings.pll_arm_div_sel && timings.pll_arm_div_sel <= 108);
+
+        let timings = Timings::target(600_000_100);
+        assert_eq!(timings.arm_hz, 600_000_000);
+    }
+
+    #[test]
+    fn imxrt1060_frequency() {
+        let expected = Timings::target(600_000_000);
+        let caccr = expected.div_arm.saturating_sub(1);
+        let cbcdr =
+            expected.div_ahb.saturating_sub(1) << 10 | expected.div_ipg.saturating_sub(1) << 8;
+        let pll_arm = expected.pll_arm_div_sel;
+
+        let actual = unsafe { timings_(&caccr, &cbcdr, &pll_arm) };
+        assert_eq!(actual, expected);
+    }
+}

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -128,11 +128,11 @@ const CSCDR2: Register =
 /// safer interface.
 #[inline(always)]
 pub unsafe fn configure(divider: u32) {
-    configure_(divider, CSCDR2);
+    configure_(divider, &CSCDR2);
 }
 
 #[inline(always)]
-unsafe fn configure_(divider: u32, reg: Register) {
+unsafe fn configure_(divider: u32, reg: &Register) {
     const OSCILLATOR: u32 = 1;
     reg.set(divider.min(64).max(1).saturating_sub(1), OSCILLATOR);
 }
@@ -140,11 +140,11 @@ unsafe fn configure_(divider: u32, reg: Register) {
 /// Returns the I2C clock frequency
 #[inline(always)]
 pub fn frequency() -> u32 {
-    frequency_(CSCDR2)
+    frequency_(&CSCDR2)
 }
 
 #[inline(always)]
-fn frequency_(reg: Register) -> u32 {
+fn frequency_(reg: &Register) -> u32 {
     let divider = reg.divider() + 1;
     CLOCK_FREQUENCY_HZ / divider
 }
@@ -165,8 +165,8 @@ mod tests {
         let mut mem: u32 = 0;
         unsafe {
             let reg = register(&mut mem);
-            configure_(65, reg);
-            assert_eq!(frequency_(reg), CLOCK_FREQUENCY_HZ / 64);
+            configure_(65, &reg);
+            assert_eq!(frequency_(&reg), CLOCK_FREQUENCY_HZ / 64);
         }
     }
 
@@ -175,8 +175,8 @@ mod tests {
         let mut mem: u32 = 0;
         unsafe {
             let reg = register(&mut mem);
-            configure_(0, reg);
-            assert_eq!(frequency_(reg), CLOCK_FREQUENCY_HZ);
+            configure_(0, &reg);
+            assert_eq!(frequency_(&reg), CLOCK_FREQUENCY_HZ);
         }
     }
 
@@ -185,8 +185,8 @@ mod tests {
         let mut mem: u32 = 0;
         unsafe {
             let reg = register(&mut mem);
-            configure_(7, reg);
-            assert_eq!(frequency_(reg), CLOCK_FREQUENCY_HZ / 7);
+            configure_(7, &reg);
+            assert_eq!(frequency_(&reg), CLOCK_FREQUENCY_HZ / 7);
         }
     }
 }

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -1,15 +1,33 @@
 //! I2C clock control
 
 use super::{
-    set_clock_gate, ClockGate, ClockGateLocation, ClockGateLocator, Disabled, Handle, I2CClock,
-    Instance,
+    set_clock_gate, ClockGate, ClockGateLocation, ClockGateLocator, Disabled, Handle, Instance,
 };
 use crate::register::{Field, Register};
+use core::marker::PhantomData;
 
 /// Base I2C clock frequency (Hz)
 const CLOCK_FREQUENCY_HZ: u32 = crate::OSCILLATOR_FREQUENCY_HZ;
 /// Default I2C peripheral clock divider
 const DEFAULT_CLOCK_DIVIDER: u32 = 3;
+
+/// The I2C clock
+///
+/// The I2C clock is based on the crystal oscillator.
+pub struct I2CClock<I>(PhantomData<I>);
+
+impl<I> I2CClock<I> {
+    /// Assume that the clock is enabled, and acquire the enabled clock
+    ///
+    /// # Safety
+    ///
+    /// This may create an alias to memory that is mutably owned by another instance.
+    /// Users should only `assume_enabled` when configuring clocks through another
+    /// API.
+    pub const unsafe fn assume_enabled() -> Self {
+        Self(PhantomData)
+    }
+}
 
 impl<I> Disabled<I2CClock<I>>
 where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,6 +176,7 @@ macro_rules! assert_not_sync {
     };
 }
 
+mod arm;
 mod gate;
 mod i2c;
 mod perclock;
@@ -186,6 +187,7 @@ mod uart;
 #[cfg(feature = "imxrt-ral")]
 pub mod ral;
 
+pub use arm::{frequency as frequency_arm, set_frequency as set_frequency_arm, ARMClock, IPGClock};
 pub use i2c::{configure as configure_i2c, frequency as frequency_i2c, I2C};
 pub use perclock::{configure as configure_perclock, frequency as frequency_perclk, GPT, PIT};
 pub use spi::{configure as configure_spi, frequency as frequency_spi, SPI};
@@ -457,6 +459,22 @@ impl Handle {
         P: Instance<Inst = PWM>,
     {
         unsafe { set_clock_gate::<P>(pwm.instance(), gate) }
+    }
+
+    /// Set the ARM clock frequency, returning the new ARM and IPG clock frequency
+    //
+    /// Changing this at runtime will affect anything that's using the ARM or IPG clocks
+    /// as inputs. Keep this in mind when changing the core clock frequency throughout
+    /// your programs.
+    #[inline(always)]
+    pub fn set_frequency_arm(hz: u32) -> (ARMClock, IPGClock) {
+        unsafe { arm::set_frequency(hz) }
+    }
+
+    /// Returns the ARM and IPG clock frequencies
+    #[inline(always)]
+    pub fn frequency_arm() -> (ARMClock, IPGClock) {
+        unsafe { arm::frequency() }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -468,12 +468,14 @@ impl Handle {
     /// your programs.
     #[inline(always)]
     pub fn set_frequency_arm(hz: u32) -> (ARMClock, IPGClock) {
+        // Safety: we own the CCM peripheral memory
         unsafe { arm::set_frequency(hz) }
     }
 
     /// Returns the ARM and IPG clock frequencies
     #[inline(always)]
     pub fn frequency_arm() -> (ARMClock, IPGClock) {
+        // Safety: we own the CCM peripheral memory
         unsafe { arm::frequency() }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -501,14 +501,14 @@ impl Handle {
     /// as inputs. Keep this in mind when changing the core clock frequency throughout
     /// your programs.
     #[inline(always)]
-    pub fn set_frequency_arm(hz: u32) -> (ARMClock, IPGClock) {
+    pub fn set_frequency_arm(&mut self, hz: u32) -> (ARMClock, IPGClock) {
         // Safety: we own the CCM peripheral memory
         unsafe { arm::set_frequency(hz) }
     }
 
     /// Returns the ARM and IPG clock frequencies
     #[inline(always)]
-    pub fn frequency_arm() -> (ARMClock, IPGClock) {
+    pub fn frequency_arm(&self) -> (ARMClock, IPGClock) {
         // Safety: we own the CCM peripheral memory
         unsafe { arm::frequency() }
     }

--- a/src/perclock.rs
+++ b/src/perclock.rs
@@ -1,12 +1,30 @@
-//! Periodic clock implementations
+//! Periodic clock
 
-use super::{
-    arm, ClockGate, ClockGateLocation, ClockGateLocator, Disabled, Handle, Instance, PerClock,
-};
+use super::{arm, ClockGate, ClockGateLocation, ClockGateLocator, Disabled, Handle, Instance};
 use crate::{
     register::{Field, Register},
     OSCILLATOR_FREQUENCY_HZ,
 };
+
+use core::marker::PhantomData;
+
+/// The periodic clock root
+///
+/// `PerClock` is the input clock for GPT and PIT.
+pub struct PerClock<P, G>(PhantomData<(P, G)>);
+
+impl<P, G> PerClock<P, G> {
+    /// Assume that the clock is enabled, and acquire the enabled clock
+    ///
+    /// # Safety
+    ///
+    /// This may create an alias to memory that is mutably owned by another instance.
+    /// Users should only `assume_enabled` when configuring clocks through another
+    /// API.
+    pub const unsafe fn assume_enabled() -> Self {
+        Self(PhantomData)
+    }
+}
 
 /// Peripheral instance identifier for GPT
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/ral.rs
+++ b/src/ral.rs
@@ -6,7 +6,10 @@
 //! The functions in this module are the same as the `clock_gate_*` functions
 //! in the library root, but they inline the RAL instance.
 
-use crate::{Instance, ADC, DCDC, DMA, GPT, I2C, PIT, PWM, SPI, UART};
+use crate::{
+    perclock::{GPT, PIT},
+    Instance, ADC, DCDC, DMA, I2C, PWM, SPI, UART,
+};
 use imxrt_ral as ral;
 
 /// Helper for a clock control module designed to the
@@ -20,7 +23,7 @@ pub type CCM = crate::CCM<
 >;
 
 /// A periodic clock that controls RAL PIT and GPT timings
-pub type PerClock = crate::PerClock<ral::pit::Instance, ral::gpt::Instance>;
+pub type PerClock = crate::perclock::PerClock<ral::pit::Instance, ral::gpt::Instance>;
 /// A UART clock that controls RAL LPUART timing
 pub type UARTClock = crate::UARTClock<ral::lpuart::Instance>;
 /// A SPI clock that controls RAL LPSPI timing

--- a/src/ral.rs
+++ b/src/ral.rs
@@ -6,7 +6,7 @@
 //! The functions in this module are the same as the `clock_gate_*` functions
 //! in the library root, but they inline the RAL instance.
 
-use crate::{Instance, ADC, DMA, GPT, I2C, PIT, PWM, SPI, UART};
+use crate::{Instance, ADC, DCDC, DMA, GPT, I2C, PIT, PWM, SPI, UART};
 use imxrt_ral as ral;
 
 /// Helper for a clock control module designed to the
@@ -46,6 +46,31 @@ impl CCM {
         unsafe { crate::CCM::new() }
     }
 }
+
+unsafe impl Instance for ral::dcdc::Instance {
+    type Inst = DCDC;
+    #[inline(always)]
+    fn instance(&self) -> DCDC {
+        DCDC
+    }
+    #[inline(always)]
+    fn is_valid(_: DCDC) -> bool {
+        true
+    }
+}
+
+/// ```no_run
+/// use imxrt_ccm::{CCM, ClockGate};
+/// use imxrt_ral::ccm;
+/// use imxrt_ral::dcdc::DCDC;
+///
+/// let CCM{ mut handle, .. } = ccm::CCM::take().map(CCM::from_ral).unwrap();
+/// let mut dcdc = DCDC::take().unwrap();
+/// handle.set_clock_gate_dcdc(&mut dcdc, ClockGate::On);
+/// handle.clock_gate_dcdc(&dcdc);
+/// ```
+#[cfg(doctest)]
+struct DCDCClockGate;
 
 unsafe impl Instance for ral::dma0::Instance {
     type Inst = DMA;

--- a/src/ral.rs
+++ b/src/ral.rs
@@ -2,13 +2,13 @@
 //!
 //! Use [`CCM::from_ral`](../struct.CCM.html#from_ral) to safely
 //! acquire the CCM handle and clock roots.
-//!
-//! The functions in this module are the same as the `clock_gate_*` functions
-//! in the library root, but they inline the RAL instance.
 
 use crate::{
+    i2c::I2C,
     perclock::{GPT, PIT},
-    Instance, ADC, DCDC, DMA, I2C, PWM, SPI, UART,
+    spi::SPI,
+    uart::UART,
+    Instance, ADC, DCDC, DMA, PWM,
 };
 use imxrt_ral as ral;
 
@@ -25,11 +25,11 @@ pub type CCM = crate::CCM<
 /// A periodic clock that controls RAL PIT and GPT timings
 pub type PerClock = crate::perclock::PerClock<ral::pit::Instance, ral::gpt::Instance>;
 /// A UART clock that controls RAL LPUART timing
-pub type UARTClock = crate::UARTClock<ral::lpuart::Instance>;
+pub type UARTClock = crate::uart::UARTClock<ral::lpuart::Instance>;
 /// A SPI clock that controls RAL LPSPI timing
-pub type SPIClock = crate::SPIClock<ral::lpspi::Instance>;
+pub type SPIClock = crate::spi::SPIClock<ral::lpspi::Instance>;
 /// An I2C clock that contorls RAL LPI2C timing
-pub type I2CClock = crate::I2CClock<ral::lpi2c::Instance>;
+pub type I2CClock = crate::i2c::I2CClock<ral::lpi2c::Instance>;
 
 impl CCM {
     /// Converts the `imxrt-ral` CCM instance into the `CCM` driver

--- a/src/register.rs
+++ b/src/register.rs
@@ -78,8 +78,13 @@ impl Register {
     #[inline(always)]
     pub fn divider(&self) -> u32 {
         // Safety: assumed valid through `new`, atomic read
-        let reg = unsafe { self.address.read_volatile() };
-        (reg & self.divider.mask) >> self.divider.offset
+        unsafe { self.divider.read(self.address) }
+    }
+    /// Returns the clock selection
+    #[inline(always)]
+    pub fn selection(&self) -> u32 {
+        // Safety: assumed valid through `new`, atomic read
+        unsafe { self.select.read(self.address) }
     }
 }
 
@@ -118,6 +123,16 @@ mod tests {
             let reg = Register::new(LPI2C_CLK_PODF, LPI2C_CLK_SEL, &mut reg);
             reg.set(3, 1);
             assert_eq!(reg.divider(), 3);
+        }
+    }
+
+    #[test]
+    fn selection() {
+        let mut reg = u32::max_value();
+        unsafe {
+            let reg = Register::new(LPI2C_CLK_PODF, LPI2C_CLK_SEL, &mut reg);
+            reg.set(3, 1);
+            assert_eq!(reg.selection(), 1);
         }
     }
 

--- a/src/register.rs
+++ b/src/register.rs
@@ -42,7 +42,6 @@ impl Field {
 }
 
 /// A CCM register
-#[derive(Clone, Copy)]
 pub struct Register {
     /// The clock divider field
     divider: Field,

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -1,11 +1,30 @@
 //! SPI clock control
 
-use super::{ClockGate, ClockGateLocation, ClockGateLocator, Disabled, Handle, Instance, SPIClock};
+use super::{ClockGate, ClockGateLocation, ClockGateLocator, Disabled, Handle, Instance};
 use crate::register::{Field, Register};
+use core::marker::PhantomData;
 
 const DEFAULT_CLOCK_DIVIDER: u32 = 5;
 /// SPI clock frequency (Hz)
 const CLOCK_FREQUENCY_HZ: u32 = 528_000_000;
+
+/// The SPI clock
+///
+/// The SPI clock is based on PLL2.
+pub struct SPIClock<S>(PhantomData<S>);
+
+impl<S> SPIClock<S> {
+    /// Assume that the clock is enabled, and acquire the enabled clock
+    ///
+    /// # Safety
+    ///
+    /// This may create an alias to memory that is mutably owned by another instance.
+    /// Users should only `assume_enabled` when configuring clocks through another
+    /// API.
+    pub const unsafe fn assume_enabled() -> Self {
+        Self(PhantomData)
+    }
+}
 
 impl<S> Disabled<SPIClock<S>>
 where

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -123,11 +123,11 @@ const CBCMR: Register = unsafe { Register::new(LPSPI_PODF, LPSPI_SEL, 0x400F_C01
 /// safer interface.
 #[inline(always)]
 pub unsafe fn configure(divider: u32) {
-    configure_(divider, CBCMR);
+    configure_(divider, &CBCMR);
 }
 
 #[inline(always)]
-unsafe fn configure_(divider: u32, reg: Register) {
+unsafe fn configure_(divider: u32, reg: &Register) {
     const PLL2: u32 = 2; // Consistent for 1062, 1011 chips
     #[cfg(not(feature = "imxrt1010"))]
     const MAX_DIVIDER: u32 = 8;
@@ -140,11 +140,11 @@ unsafe fn configure_(divider: u32, reg: Register) {
 /// Returns the SPI clock frequency
 #[inline(always)]
 pub fn frequency() -> u32 {
-    frequency_(CBCMR)
+    frequency_(&CBCMR)
 }
 
 #[inline(always)]
-fn frequency_(reg: Register) -> u32 {
+fn frequency_(reg: &Register) -> u32 {
     let divider = reg.divider() + 1;
     CLOCK_FREQUENCY_HZ / divider
 }
@@ -164,8 +164,8 @@ mod tests {
         let mut mem: u32 = 0;
         unsafe {
             let reg = register(&mut mem);
-            configure_(9, reg);
-            assert_eq!(frequency_(reg), CLOCK_FREQUENCY_HZ / 8);
+            configure_(9, &reg);
+            assert_eq!(frequency_(&reg), CLOCK_FREQUENCY_HZ / 8);
         }
     }
 
@@ -175,8 +175,8 @@ mod tests {
         let mut mem: u32 = 0;
         unsafe {
             let reg = register(&mut mem);
-            configure_(17, reg);
-            assert_eq!(frequency_(reg), CLOCK_FREQUENCY_HZ / 16);
+            configure_(17, &reg);
+            assert_eq!(frequency_(&reg), CLOCK_FREQUENCY_HZ / 16);
         }
     }
 
@@ -185,8 +185,8 @@ mod tests {
         let mut mem: u32 = 0;
         unsafe {
             let reg = register(&mut mem);
-            configure_(0, reg);
-            assert_eq!(frequency_(reg), CLOCK_FREQUENCY_HZ);
+            configure_(0, &reg);
+            assert_eq!(frequency_(&reg), CLOCK_FREQUENCY_HZ);
         }
     }
 
@@ -195,8 +195,8 @@ mod tests {
         let mut mem: u32 = 0;
         unsafe {
             let reg = register(&mut mem);
-            configure_(7, reg);
-            assert_eq!(frequency_(reg), CLOCK_FREQUENCY_HZ / 7);
+            configure_(7, &reg);
+            assert_eq!(frequency_(&reg), CLOCK_FREQUENCY_HZ / 7);
         }
     }
 }

--- a/src/uart.rs
+++ b/src/uart.rs
@@ -149,11 +149,11 @@ const CSCDR1: Register =
 /// safer interface.
 #[inline(always)]
 pub unsafe fn configure(divider: u32) {
-    configure_(divider, CSCDR1);
+    configure_(divider, &CSCDR1);
 }
 
 #[inline(always)]
-unsafe fn configure_(divider: u32, reg: Register) {
+unsafe fn configure_(divider: u32, reg: &Register) {
     const OSCILLATOR: u32 = 1; // Same value for 1060, 1010
     reg.set(divider.min(64).max(1).saturating_sub(1), OSCILLATOR);
 }
@@ -161,11 +161,11 @@ unsafe fn configure_(divider: u32, reg: Register) {
 /// Returns the UART clock frequency
 #[inline(always)]
 pub fn frequency() -> u32 {
-    frequency_(CSCDR1)
+    frequency_(&CSCDR1)
 }
 
 #[inline(always)]
-fn frequency_(reg: Register) -> u32 {
+fn frequency_(reg: &Register) -> u32 {
     let divider = reg.divider() + 1;
     CLOCK_FREQUENCY_HZ / divider
 }
@@ -186,8 +186,8 @@ mod tests {
         let mut mem: u32 = 0;
         unsafe {
             let reg = register(&mut mem);
-            configure_(65, reg);
-            assert_eq!(frequency_(reg), CLOCK_FREQUENCY_HZ / 64);
+            configure_(65, &reg);
+            assert_eq!(frequency_(&reg), CLOCK_FREQUENCY_HZ / 64);
         }
     }
 
@@ -196,8 +196,8 @@ mod tests {
         let mut mem: u32 = 0;
         unsafe {
             let reg = register(&mut mem);
-            configure_(0, reg);
-            assert_eq!(frequency_(reg), CLOCK_FREQUENCY_HZ);
+            configure_(0, &reg);
+            assert_eq!(frequency_(&reg), CLOCK_FREQUENCY_HZ);
         }
     }
 
@@ -206,8 +206,8 @@ mod tests {
         let mut mem: u32 = 0;
         unsafe {
             let reg = register(&mut mem);
-            configure_(7, reg);
-            assert_eq!(frequency_(reg), CLOCK_FREQUENCY_HZ / 7);
+            configure_(7, &reg);
+            assert_eq!(frequency_(&reg), CLOCK_FREQUENCY_HZ / 7);
         }
     }
 }

--- a/src/uart.rs
+++ b/src/uart.rs
@@ -2,13 +2,31 @@
 
 use super::{
     set_clock_gate, ClockGate, ClockGateLocation, ClockGateLocator, Disabled, Handle, Instance,
-    UARTClock,
 };
 use crate::register::{Field, Register};
+use core::marker::PhantomData;
 
 /// UART clock frequency (Hz)
 const CLOCK_FREQUENCY_HZ: u32 = super::OSCILLATOR_FREQUENCY_HZ;
 const DEFAULT_CLOCK_DIVIDER: u32 = 1;
+
+/// The UART clock
+///
+/// The UART clock is based on the crystal oscillator.
+pub struct UARTClock<C>(PhantomData<C>);
+
+impl<C> UARTClock<C> {
+    /// Assume that the clock is enabled, and acquire the enabled clock
+    ///
+    /// # Safety
+    ///
+    /// This may create an alias to memory that is mutably owned by another instance.
+    /// Users should only `assume_enabled` when configuring clocks through another
+    /// API.
+    pub const unsafe fn assume_enabled() -> Self {
+        Self(PhantomData)
+    }
+}
 
 impl<U> Disabled<UARTClock<U>>
 where

--- a/tests/ral.rs
+++ b/tests/ral.rs
@@ -2,7 +2,13 @@
 
 #![cfg(feature = "imxrt-ral")]
 
-use imxrt_ccm::{perclock::*, *};
+use imxrt_ccm::{
+    i2c::I2C,
+    perclock::{GPT, PIT},
+    spi::SPI,
+    uart::UART,
+    *,
+};
 use imxrt_ral as ral;
 
 const IMXRT1060: bool = cfg!(feature = "imxrt1060");

--- a/tests/ral.rs
+++ b/tests/ral.rs
@@ -2,7 +2,7 @@
 
 #![cfg(feature = "imxrt-ral")]
 
-use imxrt_ccm::*;
+use imxrt_ccm::{perclock::*, *};
 use imxrt_ral as ral;
 
 const IMXRT1060: bool = cfg!(feature = "imxrt1060");

--- a/tests/ral.rs
+++ b/tests/ral.rs
@@ -8,6 +8,11 @@ use imxrt_ral as ral;
 const IMXRT1060: bool = cfg!(feature = "imxrt1060");
 
 #[test]
+fn dcdc_is_valid() {
+    assert!(ral::dcdc::Instance::is_valid(DCDC));
+}
+
+#[test]
 fn dma_is_valid() {
     assert!(ral::dma0::Instance::is_valid(DMA));
 }

--- a/tests/simple_impls.rs
+++ b/tests/simple_impls.rs
@@ -29,7 +29,7 @@ fn adc_compiles() {
 struct SPI;
 
 unsafe impl ccm::Instance for SPI {
-    type Inst = ccm::SPI;
+    type Inst = ccm::spi::SPI;
     fn instance(&self) -> Self::Inst {
         unreachable!("This test doesn't run")
     }
@@ -40,7 +40,7 @@ unsafe impl ccm::Instance for SPI {
 
 #[allow(unused)]
 fn spi_compiles() {
-    let mut spi_clock = unsafe { ccm::SPIClock::<SPI>::assume_enabled() };
+    let mut spi_clock = unsafe { ccm::spi::SPIClock::<SPI>::assume_enabled() };
     let mut spi = SPI;
     spi_clock.set_clock_gate(&mut spi, ccm::ClockGate::Off);
     spi_clock.clock_gate(&spi);


### PR DESCRIPTION
The PR implements ARM clock configuration. With this PR, we can configure the ARM and IPG clock frequencies. There's both a safe and unsafe interface to the routine. Closes #1.

Now that we can control the IPG clock, we can use the IPG clock as the source for other peripherals, like periodic clocks. The PR extends the perclock interface to support clock selection. At this time, the periodic clocks are the only clocks that may run on the IPG clock.