### PR TITLE
Integrate numbered RAL instances

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,7 @@ imxrt1060 = []
 
 [dev-dependencies]
 static_assertions = "1.1"
+
+[patch.crates-io.imxrt-ral]
+git = "https://github.com/imxrt-rs/imxrt-ral"
+branch = "typenum-instances"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,7 +191,7 @@ pub use perclock::{configure as configure_perclock, frequency as frequency_percl
 pub use spi::{configure as configure_spi, frequency as frequency_spi, SPI};
 pub use uart::{configure as configure_uart, frequency as frequency_uart, UART};
 
-use core::{marker::PhantomData, ops::Deref};
+use core::marker::PhantomData;
 
 /// Describes the location of a clock gate field
 #[derive(Clone, Copy)]
@@ -295,7 +295,7 @@ pub unsafe trait Instance {
 /// Returns `Some(inst)` if `inst` is valid for this peripheral, or
 /// `None` if `inst` is not valid.
 #[inline(always)]
-fn check_instance<I: Instance + ?Sized>(inst: I::Inst) -> Option<I::Inst> {
+fn check_instance<I: Instance>(inst: I::Inst) -> Option<I::Inst> {
     Some(inst).filter(|inst| I::is_valid(*inst))
 }
 
@@ -322,7 +322,7 @@ impl ClockGateLocator for DMA {
 /// This modifies global, mutable memory that's owned by the `CCM`. Calling this
 /// function will let you change a clock gate setting for any peripheral instance.
 #[inline(always)]
-pub unsafe fn set_clock_gate<I: Instance + ?Sized>(inst: I::Inst, gate: ClockGate) {
+pub unsafe fn set_clock_gate<I: Instance>(inst: I::Inst, gate: ClockGate) {
     if let Some(inst) = check_instance::<I>(inst) {
         gate::set(&inst.location(), gate as u8)
     }
@@ -332,7 +332,7 @@ pub unsafe fn set_clock_gate<I: Instance + ?Sized>(inst: I::Inst, gate: ClockGat
 ///
 /// `get_clock_gate` returns `None` if the instance is invalid.
 #[inline(always)]
-pub fn get_clock_gate<I: Instance + ?Sized>(inst: I::Inst) -> Option<ClockGate> {
+pub fn get_clock_gate<I: Instance>(inst: I::Inst) -> Option<ClockGate> {
     check_instance::<I>(inst).map(|inst| {
         let raw = gate::get(&inst.location());
         ClockGate::from_u8(raw)
@@ -403,66 +403,60 @@ impl Handle {
     #[inline(always)]
     pub fn clock_gate_dma<D>(&self, dma: &D) -> ClockGate
     where
-        D: Deref,
-        D::Target: Instance<Inst = DMA>,
+        D: Instance<Inst = DMA>,
     {
         // Unwrap OK: we have the instance, or the `Instance`
         // implementation is incorrect.
-        get_clock_gate::<D::Target>(dma.instance()).unwrap()
+        get_clock_gate::<D>(dma.instance()).unwrap()
     }
 
     /// Set the clock gate for the DMA controller
     #[inline(always)]
     pub fn set_clock_gate_dma<D>(&mut self, dma: &mut D, gate: ClockGate)
     where
-        D: Deref,
-        D::Target: Instance<Inst = DMA>,
+        D: Instance<Inst = DMA>,
     {
-        unsafe { set_clock_gate::<D::Target>(dma.instance(), gate) };
+        unsafe { set_clock_gate::<D>(dma.instance(), gate) };
     }
 
     /// Returns the clock gate setting for the ADC
     #[inline(always)]
     pub fn clock_gate_adc<A>(&self, adc: &A) -> ClockGate
     where
-        A: Deref,
-        A::Target: Instance<Inst = ADC>,
+        A: Instance<Inst = ADC>,
     {
         // Unwrap OK: we have the instance, or the `Instance`
         // implementation is incorrect.
-        get_clock_gate::<A::Target>(adc.instance()).unwrap()
+        get_clock_gate::<A>(adc.instance()).unwrap()
     }
 
     /// Set the clock gate for the ADC peripheral
     #[inline(always)]
     pub fn set_clock_gate_adc<A>(&mut self, adc: &mut A, gate: ClockGate)
     where
-        A: Deref,
-        A::Target: Instance<Inst = ADC>,
+        A: Instance<Inst = ADC>,
     {
-        unsafe { set_clock_gate::<A::Target>(adc.instance(), gate) }
+        unsafe { set_clock_gate::<A>(adc.instance(), gate) }
     }
 
     /// Returns the clock gate setting for the ADC
     #[inline(always)]
     pub fn clock_gate_pwm<P>(&self, pwm: &P) -> ClockGate
     where
-        P: Deref,
-        P::Target: Instance<Inst = PWM>,
+        P: Instance<Inst = PWM>,
     {
         // Unwrap OK: we have the instance, or the `Instance`
         // implementation is incorrect.
-        get_clock_gate::<P::Target>(pwm.instance()).unwrap()
+        get_clock_gate::<P>(pwm.instance()).unwrap()
     }
 
     /// Set the clock gate for the PWM peripheral
     #[inline(always)]
     pub fn set_clock_gate_pwm<P>(&mut self, pwm: &mut P, gate: ClockGate)
     where
-        P: Deref,
-        P::Target: Instance<Inst = PWM>,
+        P: Instance<Inst = PWM>,
     {
-        unsafe { set_clock_gate::<P::Target>(pwm.instance(), gate) }
+        unsafe { set_clock_gate::<P>(pwm.instance(), gate) }
     }
 }
 

--- a/src/ral.rs
+++ b/src/ral.rs
@@ -12,21 +12,21 @@ use imxrt_ral as ral;
 /// Helper for a clock control module designed to the
 /// RAL interface.
 pub type CCM = crate::CCM<
-    ral::pit::Instance,
-    ral::gpt::Instance,
-    ral::lpuart::Instance,
-    ral::lpspi::Instance,
-    ral::lpi2c::Instance,
+    ral::pit::RegisterBlock,
+    ral::gpt::RegisterBlock,
+    ral::lpuart::RegisterBlock,
+    ral::lpspi::RegisterBlock,
+    ral::lpi2c::RegisterBlock,
 >;
 
 /// A periodic clock that controls RAL PIT and GPT timings
-pub type PerClock = crate::PerClock<ral::pit::Instance, ral::gpt::Instance>;
+pub type PerClock = crate::PerClock<ral::pit::RegisterBlock, ral::gpt::RegisterBlock>;
 /// A UART clock that controls RAL LPUART timing
-pub type UARTClock = crate::UARTClock<ral::lpuart::Instance>;
+pub type UARTClock = crate::UARTClock<ral::lpuart::RegisterBlock>;
 /// A SPI clock that controls RAL LPSPI timing
-pub type SPIClock = crate::SPIClock<ral::lpspi::Instance>;
+pub type SPIClock = crate::SPIClock<ral::lpspi::RegisterBlock>;
 /// An I2C clock that contorls RAL LPI2C timing
-pub type I2CClock = crate::I2CClock<ral::lpi2c::Instance>;
+pub type I2CClock = crate::I2CClock<ral::lpi2c::RegisterBlock>;
 
 impl CCM {
     /// Converts the `imxrt-ral` CCM instance into the `CCM` driver
@@ -47,7 +47,7 @@ impl CCM {
     }
 }
 
-unsafe impl Instance for ral::dma0::Instance {
+unsafe impl Instance for ral::dma0::RegisterBlock {
     type Inst = DMA;
     #[inline(always)]
     fn instance(&self) -> DMA {
@@ -74,11 +74,11 @@ struct DMAClockGate;
 
 #[cfg(not(any(feature = "imxrt1010", feature = "imxrt1060")))]
 compile_error!("Ensure that LPI2C instances are correct");
-unsafe impl Instance for ral::lpi2c::Instance {
+unsafe impl Instance for ral::lpi2c::RegisterBlock {
     type Inst = I2C;
     #[inline(always)]
     fn instance(&self) -> I2C {
-        match &**self as *const _ {
+        match &*self as *const _ {
             ral::lpi2c::LPI2C1 => I2C::I2C1,
             ral::lpi2c::LPI2C2 => I2C::I2C2,
             #[cfg(feature = "imxrt1060")]
@@ -110,11 +110,11 @@ unsafe impl Instance for ral::lpi2c::Instance {
 #[cfg(doctest)]
 struct I2CClockGate;
 
-unsafe impl Instance for ral::gpt::Instance {
+unsafe impl Instance for ral::gpt::RegisterBlock {
     type Inst = GPT;
     #[inline(always)]
     fn instance(&self) -> GPT {
-        match &**self as *const _ {
+        match &*self as *const _ {
             ral::gpt::GPT1 => GPT::GPT1,
             ral::gpt::GPT2 => GPT::GPT2,
             _ => unreachable!(),
@@ -143,7 +143,7 @@ unsafe impl Instance for ral::gpt::Instance {
 #[cfg(doctest)]
 struct GPTClockGate;
 
-unsafe impl Instance for ral::pit::Instance {
+unsafe impl Instance for ral::pit::RegisterBlock {
     type Inst = PIT;
     #[inline(always)]
     fn instance(&self) -> PIT {
@@ -171,11 +171,11 @@ struct PITClockGate;
 
 #[cfg(not(any(feature = "imxrt1010", feature = "imxrt1060")))]
 compile_error!("Ensure that LPSPI instances are correct");
-unsafe impl Instance for ral::lpspi::Instance {
+unsafe impl Instance for ral::lpspi::RegisterBlock {
     type Inst = SPI;
     #[inline(always)]
     fn instance(&self) -> SPI {
-        match &**self as *const _ {
+        match &*self as *const _ {
             ral::lpspi::LPSPI1 => SPI::SPI1,
             ral::lpspi::LPSPI2 => SPI::SPI2,
             #[cfg(feature = "imxrt1060")]
@@ -208,11 +208,11 @@ struct SPIClockGate;
 
 #[cfg(not(any(feature = "imxrt1010", feature = "imxrt1060")))]
 compile_error!("Ensure that LPUART instances are correct");
-unsafe impl Instance for ral::lpuart::Instance {
+unsafe impl Instance for ral::lpuart::RegisterBlock {
     type Inst = UART;
     #[inline(always)]
     fn instance(&self) -> UART {
-        match &**self as *const _ {
+        match &*self as *const _ {
             ral::lpuart::LPUART1 => UART::UART1,
             ral::lpuart::LPUART2 => UART::UART2,
             ral::lpuart::LPUART3 => UART::UART3,
@@ -257,11 +257,11 @@ use ral::adc1 as adc;
 
 #[cfg(not(any(feature = "imxrt1010", feature = "imxrt1060")))]
 compile_error!("Ensure that ADC instances are correct");
-unsafe impl Instance for adc::Instance {
+unsafe impl Instance for adc::RegisterBlock {
     type Inst = ADC;
     #[inline(always)]
     fn instance(&self) -> ADC {
-        match &**self as *const _ {
+        match &*self as *const _ {
             adc::ADC1 => ADC::ADC1,
             #[cfg(feature = "imxrt1060")]
             adc::ADC2 => ADC::ADC2,
@@ -297,11 +297,11 @@ use ral::pwm1 as pwm;
 
 #[cfg(not(any(feature = "imxrt1010", feature = "imxrt1060")))]
 compile_error!("Ensure that PWM instances are correct");
-unsafe impl Instance for pwm::Instance {
+unsafe impl Instance for pwm::RegisterBlock {
     type Inst = PWM;
     #[inline(always)]
     fn instance(&self) -> PWM {
-        match &**self as *const _ {
+        match &*self as *const _ {
             pwm::PWM1 => PWM::PWM1,
             #[cfg(feature = "imxrt1060")]
             pwm::PWM2 => PWM::PWM2,

--- a/src/ral.rs
+++ b/src/ral.rs
@@ -66,8 +66,8 @@ unsafe impl Instance for ral::dma0::RegisterBlock {
 ///
 /// let CCM{ mut handle, .. } = ccm::CCM::take().map(CCM::from_ral).unwrap();
 /// let mut dma = DMA0::take().unwrap();
-/// handle.set_clock_gate_dma(&mut dma, ClockGate::On);
-/// handle.clock_gate_dma(&dma);
+/// handle.set_clock_gate_dma(&mut *dma, ClockGate::On);
+/// handle.clock_gate_dma(&*dma);
 /// ```
 #[cfg(doctest)]
 struct DMAClockGate;
@@ -284,8 +284,8 @@ unsafe impl Instance for adc::RegisterBlock {
 ///
 /// let CCM{ mut handle, .. } = ccm::CCM::take().map(CCM::from_ral).unwrap();
 /// let mut adc = ADC1::take().unwrap();
-/// handle.set_clock_gate_adc(&mut adc, ClockGate::On);
-/// handle.clock_gate_adc(&adc);
+/// handle.set_clock_gate_adc(&mut *adc, ClockGate::On);
+/// handle.clock_gate_adc(&*adc);
 /// ```
 #[cfg(doctest)]
 struct ADCClockGate;
@@ -329,8 +329,8 @@ unsafe impl Instance for pwm::RegisterBlock {
 ///
 /// let CCM{ mut handle, .. } = ccm::CCM::take().map(CCM::from_ral).unwrap();
 /// let mut pwm = PWM1::take().unwrap();
-/// handle.set_clock_gate_pwm(&mut pwm, ClockGate::On);
-/// handle.clock_gate_pwm(&pwm);
+/// handle.set_clock_gate_pwm(&mut *pwm, ClockGate::On);
+/// handle.clock_gate_pwm(&*pwm);
 /// ```
 #[cfg(doctest)]
 struct PWMClockGate;

--- a/tests/ral.rs
+++ b/tests/ral.rs
@@ -9,46 +9,46 @@ const IMXRT1060: bool = cfg!(feature = "imxrt1060");
 
 #[test]
 fn dma_is_valid() {
-    assert!(ral::dma0::Instance::is_valid(DMA));
+    assert!(ral::dma0::RegisterBlock::is_valid(DMA));
 }
 
 #[test]
 fn i2c_is_valid() {
-    assert!(ral::lpi2c::Instance::is_valid(I2C::I2C1));
-    assert!(ral::lpi2c::Instance::is_valid(I2C::I2C2));
-    assert_eq!(ral::lpi2c::Instance::is_valid(I2C::I2C3), IMXRT1060);
-    assert_eq!(ral::lpi2c::Instance::is_valid(I2C::I2C4), IMXRT1060);
+    assert!(ral::lpi2c::RegisterBlock::is_valid(I2C::I2C1));
+    assert!(ral::lpi2c::RegisterBlock::is_valid(I2C::I2C2));
+    assert_eq!(ral::lpi2c::RegisterBlock::is_valid(I2C::I2C3), IMXRT1060);
+    assert_eq!(ral::lpi2c::RegisterBlock::is_valid(I2C::I2C4), IMXRT1060);
 }
 
 #[test]
 fn gpt_is_valid() {
-    assert!(ral::gpt::Instance::is_valid(GPT::GPT1));
-    assert!(ral::gpt::Instance::is_valid(GPT::GPT2));
+    assert!(ral::gpt::RegisterBlock::is_valid(GPT::GPT1));
+    assert!(ral::gpt::RegisterBlock::is_valid(GPT::GPT2));
 }
 
 #[test]
 fn pit_is_valid() {
-    assert!(ral::pit::Instance::is_valid(PIT))
+    assert!(ral::pit::RegisterBlock::is_valid(PIT))
 }
 
 #[test]
 fn spi_is_valid() {
-    assert!(ral::lpspi::Instance::is_valid(SPI::SPI1));
-    assert!(ral::lpspi::Instance::is_valid(SPI::SPI2));
-    assert_eq!(ral::lpspi::Instance::is_valid(SPI::SPI3), IMXRT1060);
-    assert_eq!(ral::lpspi::Instance::is_valid(SPI::SPI3), IMXRT1060);
+    assert!(ral::lpspi::RegisterBlock::is_valid(SPI::SPI1));
+    assert!(ral::lpspi::RegisterBlock::is_valid(SPI::SPI2));
+    assert_eq!(ral::lpspi::RegisterBlock::is_valid(SPI::SPI3), IMXRT1060);
+    assert_eq!(ral::lpspi::RegisterBlock::is_valid(SPI::SPI3), IMXRT1060);
 }
 
 #[test]
 fn uart_is_valid() {
-    assert!(ral::lpuart::Instance::is_valid(UART::UART1));
-    assert!(ral::lpuart::Instance::is_valid(UART::UART2));
-    assert!(ral::lpuart::Instance::is_valid(UART::UART3));
-    assert!(ral::lpuart::Instance::is_valid(UART::UART4));
-    assert_eq!(ral::lpuart::Instance::is_valid(UART::UART5), IMXRT1060);
-    assert_eq!(ral::lpuart::Instance::is_valid(UART::UART6), IMXRT1060);
-    assert_eq!(ral::lpuart::Instance::is_valid(UART::UART7), IMXRT1060);
-    assert_eq!(ral::lpuart::Instance::is_valid(UART::UART8), IMXRT1060);
+    assert!(ral::lpuart::RegisterBlock::is_valid(UART::UART1));
+    assert!(ral::lpuart::RegisterBlock::is_valid(UART::UART2));
+    assert!(ral::lpuart::RegisterBlock::is_valid(UART::UART3));
+    assert!(ral::lpuart::RegisterBlock::is_valid(UART::UART4));
+    assert_eq!(ral::lpuart::RegisterBlock::is_valid(UART::UART5), IMXRT1060);
+    assert_eq!(ral::lpuart::RegisterBlock::is_valid(UART::UART6), IMXRT1060);
+    assert_eq!(ral::lpuart::RegisterBlock::is_valid(UART::UART7), IMXRT1060);
+    assert_eq!(ral::lpuart::RegisterBlock::is_valid(UART::UART8), IMXRT1060);
 }
 
 #[cfg(feature = "imxrt1060")]
@@ -58,8 +58,8 @@ use ral::adc1 as adc;
 
 #[test]
 fn adc_is_valid() {
-    assert!(adc::Instance::is_valid(ADC::ADC1));
-    assert_eq!(adc::Instance::is_valid(ADC::ADC2), IMXRT1060);
+    assert!(adc::RegisterBlock::is_valid(ADC::ADC1));
+    assert_eq!(adc::RegisterBlock::is_valid(ADC::ADC2), IMXRT1060);
 }
 
 #[cfg(feature = "imxrt1060")]
@@ -69,8 +69,8 @@ use ral::pwm1 as pwm;
 
 #[test]
 fn pwm_is_valid() {
-    assert!(pwm::Instance::is_valid(PWM::PWM1));
-    assert_eq!(pwm::Instance::is_valid(PWM::PWM2), IMXRT1060);
-    assert_eq!(pwm::Instance::is_valid(PWM::PWM3), IMXRT1060);
-    assert_eq!(pwm::Instance::is_valid(PWM::PWM4), IMXRT1060);
+    assert!(pwm::RegisterBlock::is_valid(PWM::PWM1));
+    assert_eq!(pwm::RegisterBlock::is_valid(PWM::PWM2), IMXRT1060);
+    assert_eq!(pwm::RegisterBlock::is_valid(PWM::PWM3), IMXRT1060);
+    assert_eq!(pwm::RegisterBlock::is_valid(PWM::PWM4), IMXRT1060);
 }


### PR DESCRIPTION
The PR integrates the numbered RAL instances into the CCM API. Now that RAL `Instance`s are generic over a typenum, we need to change the `Instance` implementations in the `ral` module. We now implement the `Instance` trait on the `RegisterBlock`, which is a dereference away from a RAL `Instance`.

See imxrt-rs/imxrt-ral#4 for more information.